### PR TITLE
Match most specific (longest) variables first

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,15 @@ function escape ( str ) {
 	return str.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' );
 }
 
+function longest ( a, b ) {
+	return b.length - a.length;
+}
+
 export default function replace ( options = {} ) {
 	const values = options.values || options;
 	const delimiters = ( options.delimiters || [ '', '' ] ).map( escape );
-	const pattern = new RegExp( delimiters[0] + '(' + Object.keys( values ).join( '|' ) + ')' + delimiters[1], 'g' );
+	const keys = Object.keys( values ).sort( longest )
+	const pattern = new RegExp( delimiters[0] + '(' + keys.join( '|' ) + ')' + delimiters[1], 'g' );
 
 	const filter = createFilter( options.include, options.exclude );
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,5 +21,23 @@ describe( 'rollup-plugin-replace', function () {
 		});
 	});
 
+	it( 'matches most specific variables', function () {
+		return rollup.rollup({
+			entry: 'samples/basic/main.js',
+			plugins: [
+				replace({
+					BUILD: "'beta'",
+					BUILD_VERSION: "'1.0.0'"
+				})
+			]
+		}).then( function ( bundle ) {
+			const generated = bundle.generate();
+			const code = generated.code;
+
+			assert.ok( code.indexOf( "'beta' === 'beta'" ) !== -1 );
+			assert.ok( code.indexOf( "console.log( 'version:', '1.0.0' )" ) !== -1 );
+		});
+	});
+
 	// TODO tests for delimiters, sourcemaps, etc
 });

--- a/test/samples/basic/main.js
+++ b/test/samples/basic/main.js
@@ -3,3 +3,9 @@ if ( ENV !== 'production' ) {
 } else {
 	console.log( 'running...' );
 }
+
+if ( BUILD === 'beta' ) {
+	console.log( 'authorized testers build...' )
+}
+
+console.log( 'version:', BUILD_VERSION )


### PR DESCRIPTION
This fixes problems that arise when a variable name is a substring of another variable, eg. `BUILD` and `BUILD_VERSION`.

The order they are defined in the options (although ultimately decided by `Object.keys()`) ends up affecting the build, as the regex pattern generated is an alternation of all the variable names.

A naive solution (as used in this PR) is to simply sort the variables when creating the regex: `BUILD_VERSION` now takes precedence over `BUILD` regardless of their position in the options object.

_NB: Sorry for closing the previous PR. I had accidentally reused the `master` branch._
