### PR TITLE
Add support for matching word boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ rollup({
   // too permissive
   exclude: 'node_modules/**',
 
+  // By default, occurences are only matched within word
+  // boundaries. Supply empty delimiters to replace every
+  // occurence of `foo` even in the middle of words,
+  // such as `barfoobar`
+  delimiters: [ '', '' ],
+
   // To replace every occurence of `<@foo@>` instead of every
-  // occurence of `foo`, supply delimiters
+  // occurence of `\bfoo\b`, supply delimiters
   delimiters: [ '<@', '@>' ],
 
   // All other options are treated as `string: replacement`

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,13 @@ function escape ( str ) {
 	return str.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' );
 }
 
+function boundaries ( str ) {
+	return str.replace( /[\b]/g, '\\b' );
+}
+
 export default function replace ( options = {} ) {
 	const values = options.values || options;
-	const delimiters = ( options.delimiters || [ '', '' ] ).map( escape );
+	const delimiters = ( options.delimiters || [ '\b', '\b' ] ).map( escape ).map( boundaries );
 	const pattern = new RegExp( delimiters[0] + '(' + Object.keys( values ).join( '|' ) + ')' + delimiters[1], 'g' );
 
 	const filter = createFilter( options.include, options.exclude );

--- a/test/index.js
+++ b/test/index.js
@@ -21,5 +21,23 @@ describe( 'rollup-plugin-replace', function () {
 		});
 	});
 
+	it( 'respects word boundaries', function () {
+		return rollup.rollup({
+			entry: 'samples/basic/main.js',
+			plugins: [
+				replace({
+					ENV: "'production'",
+					BUILD: "'beta'"
+				})
+			]
+		}).then( function ( bundle ) {
+			const generated = bundle.generate();
+			const code = generated.code;
+
+			assert.ok( code.indexOf( "console.log( 'channel:', 'beta' )" ) !== -1 );
+			assert.ok( code.indexOf( "...REBUILDING..." ) !== -1 );
+		});
+	});
+
 	// TODO tests for delimiters, sourcemaps, etc
 });

--- a/test/samples/basic/main.js
+++ b/test/samples/basic/main.js
@@ -3,3 +3,6 @@ if ( ENV !== 'production' ) {
 } else {
 	console.log( 'running...' );
 }
+
+console.log( 'channel:', BUILD )
+console.log( '...REBUILDING...' )


### PR DESCRIPTION
Currently, values will trigger replacements in the middle of  words (see `BUILD` vs `REBUILDING` example in the [added test case](https://github.com/rollup/rollup-plugin-replace/blob/f8d57b0848229a7012b99e83866858b923f6bdc5/test/index.js#L24)).

While that may be sometimes desirable, there's no way to use `delimiters` to match word boundaries, as they are escaped before being added to the regex.

This PR adds support for raw `\b` characters in the delimiters, and makes `[ '\b', '\b' ]` their default.

Thoughts?
