### PR TITLE
Upgrade rollup to 0.41 and buble to 0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "devDependencies": {
     "eslint": "^2.13.1",
     "mocha": "^2.5.3",
-    "rollup": "^0.32.4",
-    "rollup-plugin-buble": "^0.12.1"
+    "rollup": "^0.41.6",
+    "rollup-plugin-buble": "^0.15.0"
   },
   "main": "dist/rollup-plugin-replace.cjs.js",
   "jsnext:main": "dist/rollup-plugin-replace.es.js",

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ describe( 'rollup-plugin-replace', function () {
 			const code = generated.code;
 
 			assert.ok( code.indexOf( "running in debug mode" ) === -1 );
+			assert.ok( code.indexOf( "running" ) !== -1 );
 		});
 	});
 

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ describe( 'rollup-plugin-replace', function () {
 			const generated = bundle.generate();
 			const code = generated.code;
 
-			assert.ok( code.indexOf( "'production' !== 'production'" ) !== -1 );
+			assert.ok( code.indexOf( "running in debug mode" ) === -1 );
 		});
 	});
 


### PR DESCRIPTION
It appears that the newer version supports dead code elimination, so the test must be modified.