### PR TITLE
only match on boundaries, unless delimiters are empty strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
+  - "stable"
 env:
   global:
     - BUILD_TIMEOUT=10000

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,7 @@ init:
 environment:
   matrix:
     # node.js
-    - nodejs_version: 0.12
-    - nodejs_version: 4
+    - nodejs_version: stable
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function longest(a, b) {
 
 export default function replace(options = {}) {
 	const filter = createFilter(options.include, options.exclude);
-	const delimiters = (options.delimiters || ['', '']).map(escape);
+	const { delimiters } = options;
 
 	let values;
 
@@ -30,10 +30,16 @@ export default function replace(options = {}) {
 	}
 
 	const keys = Object.keys(values).sort(longest).map(escape);
-	const pattern = new RegExp(
-		delimiters[0] + '(' + keys.join('|') + ')' + delimiters[1],
-		'g'
-	);
+
+	const pattern = delimiters ?
+		new RegExp(
+			`${escape(delimiters[0])}(${keys.join('|')})${escape(delimiters[1])}`,
+			'g'
+		) :
+		new RegExp(
+			`\\b(${keys.join('|')})\\b`,
+			'g'
+		);
 
 	// convert all values to functions
 	Object.keys(values).forEach(key => {
@@ -65,7 +71,7 @@ export default function replace(options = {}) {
 			if (!hasReplacements) return null;
 
 			let result = { code: magicString.toString() };
-			if (options.sourceMap !== false)
+			if (options.sourceMap !== false && options.sourcemap !== false)
 				result.map = magicString.generateMap({ hires: true });
 
 			return result;

--- a/test/samples/boundaries/main.js
+++ b/test/samples/boundaries/main.js
@@ -1,0 +1,2 @@
+export const foo = 'unchanged';
+export const bar = 'changed';

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('rollup-plugin-replace', () => {
 			input: 'samples/relative/main.js',
 			plugins: [
 				replace({
-					__filename: id => `'${id.slice(path.resolve(__dirname, 'samples/relative').length + 1)}'`
+					__filename: id => JSON.stringify(id.slice(path.resolve(__dirname, 'samples/relative').length + 1))
 				})
 			]
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -52,7 +52,7 @@ describe('rollup-plugin-replace', () => {
 		const module = { exports: {} };
 		fn(module, module.exports);
 
-		assert.equal(module.exports.foo, 'dir/foo.js');
+		assert.equal(module.exports.foo, path.join('dir', 'foo.js'));
 		assert.equal(module.exports.bar, 'main.js');
 	});
 


### PR DESCRIPTION
This is similar to #10, except that I didn't want to treat `\b` as a special case as I worry that might be confusing. Instead, it defaults to using word boundaries unless `delimiters` is specified — for most practical purposes it amounts to the same thing.