### PR TITLE
FIX: Stop mutating values option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default function replace(options = {}) {
 	const functionValues = Object.keys(values).reduce((acc, key) => {
 		acc[key] = functor(values[key]);
 		return acc;
-	}, {})
+	}, {});
 
 	return {
 		name: 'replace',

--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,10 @@ export default function replace(options = {}) {
 		);
 
 	// convert all values to functions
-	Object.keys(values).forEach(key => {
-		values[key] = functor(values[key]);
-	});
+	const functionValues = Object.keys(values).reduce((acc, key) => {
+		acc[key] = functor(values[key]);
+		return acc;
+	}, {})
 
 	return {
 		name: 'replace',
@@ -63,7 +64,7 @@ export default function replace(options = {}) {
 
 				start = match.index;
 				end = start + match[0].length;
-				replacement = String(values[match[1]](id));
+				replacement = String(functionValues[match[1]](id));
 
 				magicString.overwrite(start, end, replacement);
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function replace(options = {}) {
 	let values;
 
 	if (options.values) {
-		values = options.values;
+		values = Object.assign({}, options.values);
 	} else {
 		values = Object.assign({}, options);
 		delete values.delimiters;

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,19 @@ describe('rollup-plugin-replace', () => {
 		assert.equal(code.trim(), 'console.log(42);');
 	});
 
+	it('does not mutate the values map properties', async () => {
+		const valuesMap = { ANSWER: '42' }
+		const bundle = await rollup({
+			input: 'samples/basic/main.js',
+			plugins: [
+				replace({ values: valuesMap })
+			]
+		});
+
+		await bundle.generate({ format: 'es' });
+		assert.equal(valuesMap.ANSWER, '42');
+	});
+
 	it('allows replacement to be a function', async () => {
 		const bundle = await rollup({
 			input: 'samples/relative/main.js',


### PR DESCRIPTION
This issue was identified after noticing that our build pipeline that relied on the `values` variable passed to `rollup-plugin-replace` after rollup finishes its work had been mutated by the lib.