### PR TITLE
Add index.d.ts typings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ export default {
   // too permissive
   exclude: 'node_modules/**',
 
-  // To replace every occurence of `<@foo@>` instead of every
-  // occurence of `foo`, supply delimiters
+  // To replace every occurrence of `<@foo@>` instead of every
+  // occurrence of `foo`, supply delimiters
   delimiters: ['<@', '@>'],
 
   // All other options are treated as `string: replacement`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+import { Plugin } from 'rollup';
+
+type Replacement = string | ((id: string) => string);
+
+interface RollupReplaceOptions {
+	/**
+	 * A minimatch pattern, or array of patterns, of files that should be
+	 * processed by this plugin (if omitted, all files are included by default)
+	 */
+	include?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+	/**
+	 * Files that should be excluded, if `include` is otherwise too permissive.
+	 */
+	exclude?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+	/**
+	 * To replace every occurrence of `<@foo@>` instead of every occurrence
+	 * of `foo`, supply delimiters
+	 */
+	delimiters?: [string, string];
+	/**
+	 * You can separate values to replace from other options.
+	 */
+	values?: { [str: string]: Replacement };
+
+	/**
+	 * All other options are treated as `string: replacement` replacers,
+	 * or `string: (id) => replacement` functions.
+	 */
+	[str: string]: Replacement | RollupReplaceOptions['include'] | RollupReplaceOptions['values'];
+}
+
+/**
+ * Replace strings in files while bundling them.
+ */
+export default function replace(options?: RollupReplaceOptions): Plugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,6 +3869,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typescript": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.2.tgz",
+      "integrity": "sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==",
+      "dev": true
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "rollup": "^1.6.0",
     "rollup-plugin-buble": "^0.19.6",
     "shx": "^0.3.2",
-    "source-map": "^0.7.3"
+    "source-map": "^0.7.3",
+    "typescript": "^3.4.2"
   },
   "main": "dist/rollup-plugin-replace.cjs.js",
   "module": "dist/rollup-plugin-replace.es.js",
@@ -22,7 +23,7 @@
   },
   "scripts": {
     "test": "npm run test:only",
-    "test:only": "mocha",
+    "test:only": "mocha && tsc",
     "pretest": "npm run build",
     "build": "rollup -c",
     "prebuild": "shx rm -rf dist/*",
@@ -33,6 +34,7 @@
   "files": [
     "src",
     "dist",
+    "index.d.ts",
     "README.md"
   ],
   "repository": "rollup/rollup-plugin-replace",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strict": true,
+        "noEmit": true,
+        "allowJs": true
+    },
+    "files": [
+        "index.d.ts",
+        "typings-test.js"
+    ]
+}

--- a/typings-test.js
+++ b/typings-test.js
@@ -1,0 +1,28 @@
+// @ts-check
+import { dirname } from 'path';
+import replace from '.';
+
+/** @type {import("rollup").RollupOptions} */
+const config = {
+	input: 'main.js',
+	output: {
+		file: 'bundle.js',
+		format: 'iife'
+	},
+	plugins: [
+		replace({
+			include: 'config.js',
+			exclude: 'node_modules/**',
+			delimiters: ['<@', '@>'],
+			VERSION: '1.0.0',
+			ENVIRONMENT: JSON.stringify('development'),
+			__dirname: id => `'${dirname(id)}'`,
+			values: {
+				VERSION: '1.0.0',
+				ENVIRONMENT: JSON.stringify('development')
+			}
+		})
+	]
+};
+
+export default config;


### PR DESCRIPTION
My continued efforts to fully support typechecking a Rollup config with TypeScript.

TypeScript allows for checking normal Javascript files by adding a `// @ts-check` comment at the top of the file. By providing typings users can check that they aren't passing misspelled or incorrect parameters, and see a hint about what each option does in their editor.

Also fixed a typo in the README.